### PR TITLE
Criando as task para cadastrar os artigos e separação da área publica…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
+/.backlog.md
 
 # Ignore the default SQLite database.
 /db/*.sqlite3

--- a/app/controllers/administrate/docs_controller.rb
+++ b/app/controllers/administrate/docs_controller.rb
@@ -18,7 +18,7 @@ module Administrate
       @doc = current_user.docs.build(doc_params)
 
       if @doc.save
-        redirect_to(@doc)
+        redirect_to([:administrate, @doc])
       else
         render("new")
       end
@@ -28,7 +28,7 @@ module Administrate
 
     def update
       if @doc.update(doc_params)
-        redirect_to(@doc)
+        redirect_to([:administrate, @doc])
       else
         render("edit")
       end
@@ -36,7 +36,7 @@ module Administrate
 
     def destroy
       @doc.destroy
-      redirect_to(docs_path)
+      redirect_to(administrate_docs_path)
     end
 
     private

--- a/app/views/administrate/docs/_form.html.erb
+++ b/app/views/administrate/docs/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for [:administratre, @doc] do |f| %>
+<%= simple_form_for [:administrate, @doc] do |f| %>
   <%= f.input :title %>
   <%= f.input :content %>
   <%= f.button :submit, class: "button" %>

--- a/app/views/administrate/docs/index.html.erb
+++ b/app/views/administrate/docs/index.html.erb
@@ -2,13 +2,13 @@
   <div id="docs" class="clearfix">
     <% unless @docs.blank? %>
       <% @docs.each do |doc| %>
-        <a href="<%= url_for [doc] %>">
+        <%= link_to administrate_doc_path(doc) do %>
           <div class="doc">
             <p class="title"><%= doc.title %></p>
             <p class="date"><%= time_ago_in_words(doc.created_at) %></p>
             <p class="content"><%= truncate(doc.content, length: 50) %></p>
           </div>
-        </a>
+        <% end %>
       <% end %>
     <% else %>
       <h2>Create Doc!</h2>

--- a/app/views/administrate/docs/show.html.erb
+++ b/app/views/administrate/docs/show.html.erb
@@ -4,9 +4,9 @@
     <p><%= simple_format(@doc.content) %></p>
 
     <div class="buttons">
-      <%= link_to "All Docs", docs_path(@doc), class: "button" %>
+      <%= link_to "All Docs", administrate_docs_path(@doc), class: "button" %>
       <%= link_to "Edit Doc", edit_administrate_doc_path(@doc) %>
-      <%= button_to "Trash It", doc_path(@doc), method: :delete, data: { confirm: "Are you sure?" }, class: "button" %>
+      <%= button_to "Trash It", administrate_doc_path(@doc), method: :delete, data: { confirm: "Are you sure?" }, class: "button" %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,8 @@ Rails.application.routes.draw do
     resources :docs
   end
 
-  #get "welcome/index"
-  #root "docs#index", as: "authenticated_root"
+  # get "welcome/index"
+  # root "docs#index", as: "authenticated_root"
 
   root "welcome#index"
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 namespace :dev do
-  desc "Add articles to the database"
+  desc "Adicionando registros no sistema, aguarde! ;)"
   task add_articles: :environment do
-    show_spinner("Adding articles to the database") { add_articles }
+    show_spinner("Adicionando registros ao banco de dados") { add_articles }
+  end
+
+  desc "Adicionando registros no sistema, aguarde! ;)"
+  task add_docs: :environment do
+    show_spinner("Adicionando registros ao banco de dados") { add_docs }
   end
 
   def add_articles
@@ -15,7 +20,17 @@ namespace :dev do
     end
   end
 
-  def show_spinner(msg_start, msg_end = "Done!")
+  def add_docs
+    50.times do
+      Doc.create(
+        title: Faker::Lorem.sentence.delete("."),
+        content: Faker::Lorem.paragraph(sentence_count: rand(100..200)),
+        user: User.all.sample,
+      )
+    end
+  end
+
+  def show_spinner(msg_start, msg_end = "Adicionado!")
     spinner = TTY::Spinner.new("[:spinner] #{msg_start}")
     spinner.auto_spin
     yield


### PR DESCRIPTION
- [x] Separa claramente a área administrativa da área pública, garantindo que cada uma tenha suas próprias permissões de acesso e funcionalidades distintas.

- [x] Habilite a visualização dos artigos no índice, permitindo que os usuários possam facilmente encontrar e navegar pelos conteúdos disponíveis.

- [x] Crie duas novas tarefas no sistema: uma chamada Administrate, destinada a atividades de administração e gerenciamento do sistema, e outra chamada Doc, destinada à documentação e organização de informações relevantes.